### PR TITLE
[CNIO-535] Multiply asset value with asset quantity

### DIFF
--- a/projects/danogo/index.js
+++ b/projects/danogo/index.js
@@ -22,11 +22,15 @@ const fetchSmartContractUTXOs = async (address) => {
   return kupoResponse.data;
 }
 
-const fetchAssetValue = async (assetIds) => {
+const fetchAssetValue = async (assetsInfo) => {
+  const assetIds = Object.keys(assetsInfo)
+  let totalAssetsValue = 0;
   const gatewayResponse = await postURL(`${DANOGO_GATEWAY_ENDPOINT}/cardano-asset-value`, { assetIds: assetIds});
-  return gatewayResponse.data.data.assetValues
-    .map((asset) => Number(BigInt(asset.adaValue) * BigInt(100) / BigInt(ADA_TO_LOVELACE)) / 100)
-    .reduce((accumulator, currentValue) => accumulator + currentValue, 0);
+  gatewayResponse.data.data.assetValues.forEach((asset) => {
+    const assetValue = Number(BigInt(asset.adaValue) * BigInt(100) / BigInt(ADA_TO_LOVELACE)) / 100;
+    totalAssetsValue += assetValue * assetsInfo[asset.assetId];
+  });
+  return totalAssetsValue;
 }
 
 const fetch = async () => {
@@ -36,18 +40,16 @@ const fetch = async () => {
     return fetchSmartContractUTXOs(address)
   }));
 
-  let assetIds = [];
+  let assetInfos = {};
   let totalValueLocked = 0;
   smartContractsUtxos.forEach(async (smUtxos) => {
     smUtxos.forEach((utxo) => {
       totalValueLocked += utxo.value.coins / ADA_TO_LOVELACE;
-      Object.keys(utxo.value.assets).forEach((assetId) => {
-        assetIds.push(assetId);
-      })
+      assetInfos = {...assetInfos, ...utxo.value.assets}
     })
   });
 
-  const totalAssetsValues = await fetchAssetValue(assetIds);
+  const totalAssetsValues = await fetchAssetValue(assetInfos);
   totalValueLocked += totalAssetsValues;
 
   return { cardano: totalValueLocked };


### PR DESCRIPTION
Problem:
  - Asset value is not multiplied with asset quantity, leading to incorrect Total Value Locked

Changes:
  - Create a new empty object called `assetInfos`, to store `assetId` as key and asset quantity as values
  - Call Danogo gateway to retrieve single asset value for each assetId
  - Multiply the retrieved asset value with asset quantity from `assetInfos`
  - Plus the multiplied value to `totalAssetsValue`

Test:
![image](https://github.com/anhtv-teko/DefiLlama-Adapters/assets/142006359/cf2d7087-2fda-4c2e-a711-1670370257f3)

